### PR TITLE
Fix minor typo (`rintln`)

### DIFF
--- a/first-steps/03-channels-dsl2.nf
+++ b/first-steps/03-channels-dsl2.nf
@@ -9,7 +9,7 @@ nextflow.enable.dsl=2
 
 params.dir = 'data/*.fastq.gz'
 
-rintln " -- FILES CHANNELS -- "
+println " -- FILES CHANNELS -- "
 
 read_ch = Channel.fromPath( params.dir, checkIfExists: true )
 

--- a/first-steps/03-channels-paired-dsl2.nf
+++ b/first-steps/03-channels-paired-dsl2.nf
@@ -7,7 +7,7 @@ nextflow.enable.dsl=2
 // Its important to have the correct pattern here (can be tested with "ls")
 params.dir = 'data/*_R{1,2}.fastq.gz'
 
-rintln " -- PAIRED-END READS CHANNELS -- "
+println " -- PAIRED-END READS CHANNELS -- "
 
 read_ch = Channel.fromFilePairs( params.dir, checkIfExists: true )
 


### PR DESCRIPTION
Hello!
First of all I would like to thank you for this tutorial! It's very useful!

Going through the examples with channels, I found a small typo in the first-steps scripts.
This PR changes `rintln` to `println` in `03-channels-dsl2.nf` and `03-channels-paired-dsl2.nf`.

With kind regards,
Vladimir